### PR TITLE
Add support for `pika==1.0.0b2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
     # See https://caremad.io/2013/07/setup-vs-requirement/ for an explanation and
     # http://blog.miguelgrinberg.com/post/the-package-dependency-blues
     # for a useful dicussion
-    install_requires=['tornado>=4.0, <6.0', 'pika==1.0.0b1', 'pyyaml>=3.0, <4.0', 'shortuuid', 'six', 'furl'],
+    install_requires=['tornado>=4.0, <6.0', 'pika>=1.0.0b2', 'pyyaml>=3.0, <4.0', 'shortuuid', 'six', 'furl'],
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'ipython', 'twine', 'pre-commit', 'yapf', 'prospector', 'future'],
+        'dev': ['pytest>=4', 'pytest-cov', 'ipython', 'twine', 'pre-commit', 'yapf', 'prospector', 'future'],
         ':python_version<"3.5"': ['typing'],
         ':python_version<"3.4"': ['enum34', 'singledispatch'],
         ':python_version<"3.3"': ['mock'],

--- a/test/test_amqp.py
+++ b/test/test_amqp.py
@@ -675,7 +675,7 @@ class TestCase(BaseTestCase):
     @testing.gen_test
     def test_set_qos(self):
         channel = yield self.create_channel()
-        yield channel.set_qos(prefetch_count=1, all_channels=True)
+        yield channel.set_qos(prefetch_count=1, global_qos=True)
 
     @testing.gen_test
     def test_exchange_delete(self):

--- a/topika/channel.py
+++ b/topika/channel.py
@@ -43,7 +43,7 @@ class Channel(BaseChannel):
         Create a new instance of the Channel.  Don't call this directly, this should
         be constructed by the connection.
 
-        :type connection: :class:`pika.TornadoConnection`
+        :type connection: :class:`pika.adapters.tornado_connection.TornadoConnection`
         :type loop: :class:`tornado.ioloop.IOLoop`
         :param future_store: The future store to use
         :type future_store: :class:`topika.common.FutureStore`
@@ -254,7 +254,7 @@ class Channel(BaseChannel):
 
     @BaseChannel._ensure_channel_is_open
     @gen.coroutine
-    def _publish(self, queue_name, routing_key, body, properties, mandatory, immediate):
+    def _publish(self, queue_name, routing_key, body, properties, mandatory):
         """
         :type properties: :class:`pika.BasicProperties`
         """
@@ -271,7 +271,7 @@ class Channel(BaseChannel):
                 properties.headers['delivery-tag'] = str(self._delivery_tag)
 
             try:
-                self._channel.basic_publish(queue_name, routing_key, body, properties, mandatory, immediate)
+                self._channel.basic_publish(queue_name, routing_key, body, properties, mandatory)
             except (AttributeError, RuntimeError) as exc:
                 LOGGER.exception("Failed to send data to client (connection unexpectedly closed)")
                 self._on_channel_close(self._channel, exc)
@@ -337,11 +337,11 @@ class Channel(BaseChannel):
 
     @BaseChannel._ensure_channel_is_open
     @gen.coroutine
-    def set_qos(self, prefetch_count=0, prefetch_size=0, all_channels=False, timeout=None):
+    def set_qos(self, prefetch_count=0, prefetch_size=0, global_qos=False, timeout=None):
         """
         :type prefetch_count: int
         :type prefetch_size: int
-        :type all_channels: bool
+        :type global_qos: bool
         :type timeout: int
         """
 
@@ -351,7 +351,7 @@ class Channel(BaseChannel):
             self._channel.basic_qos(
                 prefetch_size=prefetch_size,
                 prefetch_count=prefetch_count,
-                all_channels=all_channels,
+                global_qos=global_qos,
                 callback=f.set_result,
             )
 

--- a/topika/connection.py
+++ b/topika/connection.py
@@ -5,6 +5,7 @@ import pika
 from pika import ConnectionParameters
 from pika.credentials import ExternalCredentials, PlainCredentials
 from pika.spec import REPLY_SUCCESS
+from pika.adapters.tornado_connection import TornadoConnection
 import pika.exceptions
 import tornado.ioloop
 from tornado import gen, ioloop, locks
@@ -156,7 +157,7 @@ class Connection(object):
         .. note::
             This method is called by :func:`connect`. You shouldn't call it explicitly.
 
-        :rtype: :class:`pika.TornadoConnection`
+        :rtype: :class:`pika.adapters.tornado_connection.TornadoConnection`
         """
 
         if self.__closing and self.__closing.done():
@@ -169,7 +170,7 @@ class Connection(object):
 
             connect_future = tools.create_future(loop=self.loop)
 
-            connection = pika.TornadoConnection(
+            connection = TornadoConnection(
                 parameters=self.__connection_parameters,
                 custom_ioloop=self.loop,
                 on_open_callback=connect_future.set_result,
@@ -285,7 +286,7 @@ class Connection(object):
     def _on_connection_refused(self, future, connection, reason):
         """
         :type future: :class:`tornado.concurrent.Future`
-        :type connection: :class:`pika.TornadoConnection`
+        :type connection: :class:`pika.adapters.tornado_connection.TornadoConnection`
         :type reason: Exception
         """
         self._on_connection_lost(future, connection, reason)
@@ -293,7 +294,7 @@ class Connection(object):
     def _on_connection_lost(self, future, connection, reason):
         """
         :type future: :class:`tornado.concurrent.Future`
-        :type connection: :class:`pika.TornadoConnection`
+        :type connection: :class:`pika.adapters.tornado_connection.TornadoConnection`
         :type reason: Exception
         """
         if self.__closing and self.__closing.done():

--- a/topika/exceptions.py
+++ b/topika/exceptions.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 from pika.exceptions import (ProbableAuthenticationError, AMQPChannelError, AMQPConnectionError, AMQPError,
                              ChannelClosed, ChannelError, AuthenticationError, BodyTooLongError, ConnectionClosed,
                              ConsumerCancelled, DuplicateConsumerTag, IncompatibleProtocolError, InvalidChannelNumber,
-                             InvalidFieldTypeException, InvalidFrameError, InvalidMaximumFrameSize,
-                             InvalidMinimumFrameSize, MethodNotImplemented, NackError, NoFreeChannels,
+                             InvalidFieldTypeException, InvalidFrameError, MethodNotImplemented, NackError, NoFreeChannels,
                              ProbableAccessDeniedError, ProtocolSyntaxError, ProtocolVersionMismatch,
                              ShortStringTooLong, UnexpectedFrameError, UnroutableError, UnsupportedAMQPFieldException)
 
@@ -40,8 +39,6 @@ __all__ = (
     'InvalidChannelNumber',
     'InvalidFieldTypeException',
     'InvalidFrameError',
-    'InvalidMaximumFrameSize',
-    'InvalidMinimumFrameSize',
     'MessageProcessError',
     'MethodNotImplemented',
     'NackError',

--- a/topika/exchange.py
+++ b/topika/exchange.py
@@ -188,7 +188,7 @@ class Exchange(BaseChannel):
 
     @BaseChannel._ensure_channel_is_open
     @gen.coroutine
-    def publish(self, message, routing_key, mandatory=True, immediate=False):
+    def publish(self, message, routing_key, mandatory=True):
         """ Publish the message to the queue. `topika` use `publisher confirms`_
         extension for message delivery.
 
@@ -207,8 +207,7 @@ class Exchange(BaseChannel):
             routing_key,
             message.body,
             properties=message.properties,
-            mandatory=mandatory,
-            immediate=immediate)))
+            mandatory=mandatory)))
 
     @BaseChannel._ensure_channel_is_open
     def delete(self, if_unused=False):

--- a/topika/robust_channel.py
+++ b/topika/robust_channel.py
@@ -35,7 +35,7 @@ class RobustChannel(Channel):
                  on_return_raises=False):
         """
 
-        :param connection: :class:`pika.TornadoConnection` instance
+        :param connection: :class:`pika.adapters.tornado_connection.TornadoConnection` instance
         :param loop: Event loop (:func:`tornado.ioloop.IOLoop.current()` when :class:`None`)
         :param future_store: :class:`topika.common.FutureStore` instance
         :param publisher_confirms: False if you don't need delivery confirmations (in pursuit of performance)
@@ -85,8 +85,8 @@ class RobustChannel(Channel):
         raise gen.Return(result)
 
     @gen.coroutine
-    def set_qos(self, prefetch_count=0, prefetch_size=0, all_channels=False, timeout=None):
-        if all_channels:
+    def set_qos(self, prefetch_count=0, prefetch_size=0, global_qos=False, timeout=None):
+        if global_qos:
             raise NotImplementedError("Not available to RobustConnection")
 
         self._qos = prefetch_count, prefetch_size

--- a/topika/robust_connection.py
+++ b/topika/robust_connection.py
@@ -90,7 +90,7 @@ class RobustConnection(Connection):
     def _on_connection_lost(self, future, connection, reason):
         """
         :type future: :class:`tornado.concurrent.Future`
-        :type connection: :class:`pika.TornadoConnection`
+        :type connection: :class:`pika.adapters.tornado_connection.TornadoConnection`
         :type reason: Exception
         """
         for callback in self._on_connection_lost_callbacks:


### PR DESCRIPTION
Fixes #3 

The changes in `pika==1.0.0b2` introduce a number of backwards
incompatible changes with respect to the first beta version and the
`0.13.*` series. Here we up the requirement and adapt the API.